### PR TITLE
Fixed broken/stale FD.io links

### DIFF
--- a/content/documentation/csit.md
+++ b/content/documentation/csit.md
@@ -6,13 +6,13 @@ title = "CSIT Documentation"
 The FD.io software is being continuosly be tested with the tools and
 framework provided by the CSIT project (Continuous System Integration and Testing).
 
-The project description can be found here [CSIT Project](https://s3-docs.fd.io/csit/master/docs/).
+The project description can be found here [CSIT Project](https://s3-docs.fd.io/csit/master/docs/overview.html).
 
 Reports are published on a release basis at [CSIT Report](https://s3-docs.fd.io/csit/master/report/).
 
 Data on FD.io trending performance is found at [CSIT Trending](https://s3-docs.fd.io/csit/master/trending/).
 
-The archive of all the CSIT documents is at [CSIT Archive](https://docs.fd.io/csit/)
+<!-- The archive of all the CSIT documents is at [CSIT Archive](https://docs.fd.io/csit/) -->
 
 ----------------------
 
@@ -57,7 +57,6 @@ SW - IPSEC tunnel termination, with standard protocol checks.
 
 
 {{% btn-dropdown "For All the CSIT Test Reports" %}}
-{{% btn-dropelem txt="Latest Release (2106)" link="https://s3-docs.fd.io/csit/rls2106/report/" %}}
+{{% btn-dropelem txt="Latest Release (2206)" link="https://s3-docs.fd.io/csit/master/report/" %}}
 {{% btn-dropdiv %}}
-{{% btn-dropelem txt="Master" link="https://s3-docs.fd.io/csit/master/report/" %}}
 {{%/ btn-dropdown %}}

--- a/content/gettingstarted/building.md
+++ b/content/gettingstarted/building.md
@@ -50,7 +50,7 @@ $ make build-release
 ### Running VPP
 
 After building the VPP binaries, you now have several images built. Run these VPP
-with the follwoing
+with the following
 
 ``` console
 $ sudo bash
@@ -58,8 +58,8 @@ $ sudo bash
 ```
 
 {{% btn-dropdown "Developing with VPP" %}}
-{{% btn-dropelem txt="Latest Release" link="/docs/vpp/master/gettingstarted/developers" %}}
+{{% btn-dropelem txt="Latest Release" link="/docs/vpp/master/developer/build-run-debug/index.html" %}}
 {{% btn-dropdiv %}}
-{{% btn-dropelem txt="version 22.06" link="/docs/vpp/v2206/gettingstarted/developers" %}}
-{{% btn-dropelem txt="version 22.01" link="/docs/vpp/v2201/gettingstarted/developers" %}}
+{{% btn-dropelem txt="version 22.06" link="/docs/vpp/v2206/developer/build-run-debug/index.html" %}}
+{{% btn-dropelem txt="version 22.02" link="/docs/vpp/v2202/developer/build-run-debug/index.html" %}}
 {{%/ btn-dropdown %}}

--- a/content/gettingstarted/building.md
+++ b/content/gettingstarted/building.md
@@ -58,8 +58,8 @@ $ sudo bash
 ```
 
 {{% btn-dropdown "Developing with VPP" %}}
-{{% btn-dropelem txt="Latest Release" link="/docs/vpp/latest/gettingstarted/developers" %}}
+{{% btn-dropelem txt="Latest Release" link="/docs/vpp/master/gettingstarted/developers" %}}
 {{% btn-dropdiv %}}
-{{% btn-dropelem txt="version 21.06" link="/docs/vpp/v2106/gettingstarted/developers" %}}
-{{% btn-dropelem txt="version 21.01" link="/docs/vpp/v2101/gettingstarted/developers" %}}
+{{% btn-dropelem txt="version 22.06" link="/docs/vpp/v2206/gettingstarted/developers" %}}
+{{% btn-dropelem txt="version 22.01" link="/docs/vpp/v2201/gettingstarted/developers" %}}
 {{%/ btn-dropdown %}}

--- a/content/gettingstarted/installing.md
+++ b/content/gettingstarted/installing.md
@@ -59,8 +59,8 @@ Uninstall the  packages by running the following command:
 ```
 
 {{% btn-dropdown "More About Installing VPP" %}}
-{{% btn-dropelem txt="Latest Release" link="/docs/vpp/latest/gettingstarted/installing" %}}
+{{% btn-dropelem txt="Latest Release" link="/docs/vpp/master/gettingstarted/installing" %}}
 {{% btn-dropdiv %}}
-{{% btn-dropelem txt="version 21.06" link="/docs/vpp/v2106/gettingstarted/installing" %}}
-{{% btn-dropelem txt="version 21.01" link="/docs/vpp/v2101/gettingstarted/installing" %}}
+{{% btn-dropelem txt="version 22.06" link="/docs/vpp/v2206/gettingstarted/installing" %}}
+{{% btn-dropelem txt="version 22.02" link="/docs/vpp/v2202/gettingstarted/installing" %}}
 {{%/ btn-dropdown %}}

--- a/content/latest/news/bolsters-kubernetes.md
+++ b/content/latest/news/bolsters-kubernetes.md
@@ -1,6 +1,6 @@
 +++
 title = "SDxCentral: FD.io Bolsters Kubernetes, NFV, and Istio Support With Latest Release"
-author = "Jill Lovato"
+author = "Dan Meyer"
 link = "https://www.sdxcentral.com/articles/news/fd-io-bolsters-kubernetes-nfv-and-istio-support-with-latest-release/2018/03/?utm_source=SDxCentral.com+Mailing+List&utm_campaign=73235e265b-SDxCentral+Newsletter+2018-03-22&utm_medium=email&utm_term=0_c2b6e504a2-73235e265b-82038913"
 linkText = "Read More at SDx Central"
 

--- a/content/latest/news/cisco-blogs.md
+++ b/content/latest/news/cisco-blogs.md
@@ -1,8 +1,8 @@
 +++
 title = "Cisco Blogs: A Bigger Helping of Internet Please!"
-author = "Jeska Duman"
+author = "Maciek Konstantynowicz and David Ward"
 
-date = "2016-04-07"
+date = "2016-04-04"
 +++
 
 “Holy Sh*t, that’s fast and feature rich” is the most common response we’ve heard from folks that

--- a/content/latest/news/hicn.md
+++ b/content/latest/news/hicn.md
@@ -18,4 +18,4 @@ Additionally, applications can take advantage of a new set of name-based transpo
 
 While the project is use case-agnostic, the development is made to support some key industrial applications such as 5G, Internet of Things (IoT), Mobile Edge Computing and Cloud native applications.
 
-More details on FD.io’s  hICN project will be available onsite  at Mobile World Congress, February 25-28th in Barcelona, at the Cisco booth Hall 3 Stand 3E30. If you aren’t going to make it to Mobile World Congress, you can also come and talk to us at  [IETF 104](https://www.ietf.org/how/meetings/104/?gclid=EAIaIQobChMIj5LT_Za84AIVUhx9Ch01xg_7EAAYASAAEgJ2FPD_BwE) in Prague, March 23-29 and [KubeCon/CloudNativeCon](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2019/) in Barcelona, May 20-23. Stay tuned for other chances to see us throughout the year!  
+If you aren’t going to make it to this year's Mobile World Congress, you can also come and talk to us in early 2023 at [KubeCon/CloudNativeCon](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/) in Amsterdam, April 17-21. Stay tuned for other chances to see us throughout the year!

--- a/content/latest/news/improve-kubernetes.md
+++ b/content/latest/news/improve-kubernetes.md
@@ -1,6 +1,6 @@
 +++
 title = "FierceTelecom: FD.io improves Kubernetes networking in sixth software release"
-author = "Jill Lovato"
+author = "Sean Buckley"
 link = "https://www.fiercetelecom.com/telecom/fd-io-improves-kubernetes-networking-sixth-software-release"
 linkText = "Read More at Fierce Telecom"
 

--- a/content/latest/news/lf-virtual-switch.md
+++ b/content/latest/news/lf-virtual-switch.md
@@ -1,10 +1,10 @@
 +++
 title = "FierceTelecom: Linux Foundation’s FD.io virtual switch project doubles packet throughput to terabit speed"
-author = "Jeska Duman"
+author = "Sean Buckley"
 link = "https://www.fiercetelecom.com/telecom/linux-foundation-s-fd-io-virtual-switch-project-doubles-packet-throughput-to-terabit-speeds"
 linkText = "Read More at Fierce Telecom"
 
-date = "2017-07-19"
+date = "2017-07-11"
 +++
 
 The Linux Foundation’s Fast Data (FD.io, or Fido) collaborative software project is

--- a/content/latest/news/light-reading-networks-on-demand.md
+++ b/content/latest/news/light-reading-networks-on-demand.md
@@ -1,6 +1,6 @@
 +++
 title = "Light Reading: The Future Is Networks on Demand, Says Cisco Chief Architect"
-author = "Jeska Duman"
+author = "Mitch Wagner"
 
 date = "2016-03-09"
 +++

--- a/content/latest/news/light-reading-verizon.md
+++ b/content/latest/news/light-reading-verizon.md
@@ -1,6 +1,6 @@
 +++
 title = "Light Reading: Verizon, Cisco Lab Test ‘Information-Centric Networking’"
-author = "Jill Lovato"
+author = "Mari Silbey"
 link = "https://www.lightreading.com/video/video-storage-delivery/verizon-cisco-lab-test-information-centric-networking/d/d-id/741539"
 linkText = "Read More at Light Reading"
 

--- a/content/latest/news/packet-speeds-double.md
+++ b/content/latest/news/packet-speeds-double.md
@@ -1,10 +1,10 @@
 +++
 title = "SDxCentral: FD.io Sees Packet Speeds Double with Intel’s New Chips"
-author = "Jeska Duman"
+author = "Linda Hardesty"
 link = "https://www.sdxcentral.com/articles/news/fd-io-sees-packet-speeds-double-intels-new-chips/2017/07/"
 linkText = "Read More at SDX Central"
 
-date = "2017-07-19"
+date = "2017-07-13"
 +++
 
 The open source Fast Data Project (FD.io) announced double performance gains made

--- a/content/latest/news/pq-show.md
+++ b/content/latest/news/pq-show.md
@@ -1,10 +1,10 @@
 +++
 title = "PQ Show 85: FD.IO & VPP Open Virtual Switch"
-author = "Jeska Duman"
+author = "Drew Conry-Murray"
 link = "https://packetpushers.net/podcast/pq-show-85-fd-io-vpp-open-source-virtual-switch/"
 linkText = "Listen at Packet Pushers"
 
-date = "2016-07-16"
+date = "2016-07-07"
 +++
 
 The virtual switch in the hypervisor has been a highly competitive space for a number of years, with

--- a/content/latest/news/unmasking-fdio.md
+++ b/content/latest/news/unmasking-fdio.md
@@ -1,6 +1,6 @@
 +++
 title = "SDXCentral: Un-Masking FD.io – the Open Source Project that Processes Packets"
-author = "Jeska Duman"
+author = "Linda Hardesty"
 link = "https://www.sdxcentral.com/articles/news/un-masking-fd-io-open-source-project-processes-packets/2017/04/"
 linkText = "Read More at SDX Central"
 

--- a/content/latest/webinars/2021_10_15_calico_vpp_using_calico_pluggable_dataplanes.md
+++ b/content/latest/webinars/2021_10_15_calico_vpp_using_calico_pluggable_dataplanes.md
@@ -4,7 +4,7 @@ title = "Calico/VPP: Using Calico’s Pluggable Dataplanes for Fun and Fast Netw
 date = "2021-10-15"
 time_slot = "11:55am - 12:30am PST"
 type = "webinar"
-youtubeurl = "https://www.youtube.com/watch?v=tPnqFx32rW4"
+youtubeurl = "https://www.youtube.com/watch?v=9zBu4Zcf__c"
 pdfurl =  "https://static.sched.com/hosted_files/kccncna2021/4c/Calico_VPP%20KCNA%202021.pdf"
 ppturl = "https://static.sched.com/hosted_files/kccncna2021/21/Calico_VPP-KCNA2021.pptx"
 +++

--- a/content/overview/usecases.md
+++ b/content/overview/usecases.md
@@ -75,17 +75,13 @@ FD.io VPP has four different Access Control List technologies; ranging from the 
 
 ## Deployment Models
 
-**FD.io is being used in Discrete Appliances, Virtual Network Functions (VNFs) and for Cloud Native Functions (CNFs) for example:**
-
-### <img src="/img/router.png" width=5% >  Discrete Appliances
-
-**Netconf & Yang support is provided with [Sweetcomb](https://wiki.fd.io/view/Sweetcomb).**
+**FD.io is being used in Virtual Network Functions (VNFs) and for Cloud Native Functions (CNFs) for example:**
 
 
 ### <img src="/img/openstack02.png" width=10% > Virtual Network Functions
-**Openstack support is provided with [Networking VPP](https://github.com/openstack/networking-vpp) or [Open Daylight](https://www.opendaylight.org) as your OpenStack Neutron ML2 Driver.**
+**Openstack support is provided with [Networking VPP](https://opendev.org/x/networking-vpp) or [Open Daylight](https://www.opendaylight.org) as your OpenStack Neutron ML2 Driver.**
 
-
+<!-- original "networking VPP" link: https://github.com/openstack/networking-vpp -->
 
 ### <img src="/img/docker.png" width=10% > Cloud Network Functions
 
@@ -93,5 +89,6 @@ FD.io VPP has four different Access Control List technologies; ranging from the 
 
 You can use it by configure the Calico CNI to use VPP as its dataplane.
 
-Previous projects addressing this were [Ligato](https://ligato.io/) and [Contiv/VPP](https://github.com/contiv/vpp) as your Kubernetes CNI providers.
+<!-- Previous projects addressing this were [Ligato](https://ligato.io/) and [Contiv/VPP](https://github.com/contiv/vpp) as your Kubernetes CNI providers. -->
+
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -2,6 +2,8 @@
 # options available here :
 # https://docs.netlify.com/routing/redirects/redirect-options/
 /docs/vpp/master/*     https://s3-docs.fd.io/vpp/22.10/:splat            302
+/docs/vpp/v2206/*      https://s3-docs.fd.io/vpp/22.06/:splat            302
+/docs/vpp/v2202/*      https://s3-docs.fd.io/vpp/22.02/:splat            302
 /docs/vpp/v2110/*      https://s3-docs.fd.io/vpp/21.10/:splat            302
 /docs/vpp/v2106/*      https://s3-docs.fd.io/vpp/21.06.0/:splat          302
 /docs/hicn/latest/*    https://hicn.readthedocs.io/:splat                302


### PR DESCRIPTION
Hi all. Over the past couple weeks, I have noticed some stale and/or broken links, or links leading to the wrong source, on FD.io.  I have analyzed each page of FD.io's five sections and fixed whichever broken/stale links I found on each one. This pull request contains my changes so far. Thank you.