### PR TITLE
Remove old VPP Release 20.01 info from landing page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,12 +21,7 @@
 							Make sure your packet traffic keeps up.
 							<br><br>
 							Enriching Data Plane Leadership and Deployment Efficiency.
-							<br>
-							The Fast Data Project's VPP Release 20.01 is here!
                     	</p>
-		    	<br>
-		    	<a href="https://www.lfnetworking.org/blog/2020/07/27/fd-io-introduces-vpp-release-20-05/" class="btn btn-main">
-				Features and Perfomance of the VPP Release</a>
                 	</div>
             	</div>
         	</div>


### PR DESCRIPTION
Remove old VPP Release 20.01 info from landing page

- Including button redirecting to the VPP v20.05 release documentation

Signed-off-by: Dave Wallace <dwallacelf@gmail.com>