### PR TITLE
FD.io users: update url to point to IPng Networks articles

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -240,10 +240,10 @@
 					)
 				}}
 				{{ partial "usecases.html" (dict
-					"href" "https://ipng.ch"
+					"href" "https://ipng.ch/s/articles/"
 					"img" "/img/logos/IPng-network.png"
 					"title" "IPng Networks"
-					"content" "IPng Networks is a contributer to the Linux CP plugin and is also a downstream user"
+					"content" "IPng Networks is a contributer to the Linux CP plugin and source of in-depth technical articles on the VPP ecosystem"
 					)
 				}}
 				{{ partial "usecases.html" (dict


### PR DESCRIPTION
- instead of linking to top site, link to the blog articles about VPP & other networking topics