### PR TITLE
news: VPP 24.02 Release, CSIT 24.02 Report, and Calico-vpp 3.27.0

### DIFF
--- a/content/news/press/calico_vpp_v3.27.0_release.md
+++ b/content/news/press/calico_vpp_v3.27.0_release.md
@@ -1,0 +1,11 @@
++++
+title = "Calico-VPP is GA in Calico v3.27.0 release on 19th of December 2023"
+author = "lfnetworking"
+link = "https://www.tigera.io/blog/deep-dive/calico-vpp-empowering-high-performance-kubernetes-networking-with-userspace-packet-processing/"
+
+linkText = "Read More About Calico-VPP v3.27.0 release"
+
+date = "2024-04-03"
++++
+
+**Calico-VPP is GA in Calico v3.27.0 release on 19th of December 2023** -- The Calico-VPP v3.27.0 release includes lots of new documentation, v6 rules in BGPFilters, vpp upgrade to latest and others. Complete list of features and bug fixes can be found in the Release notes on GitHub [here](https://github.com/projectcalico/vpp-dataplane/blob/master/RELEASE_NOTES.md)!

--- a/content/news/press/csit2402.md
+++ b/content/news/press/csit2402.md
@@ -1,0 +1,10 @@
++++
+title = "CSIT 24.02 Report on 13th of March 2024"
+author = "lfnetworking"
+link = "https://csit.fd.io/cdocs/release_notes/current/"
+linkText = "Read More About CSIT 24.02 Report"
+
+date = "2024-03-13"
++++
+
+**CSIT 24.02 Report on 13th of March 2024** -- The CSIT report information can be found in csit.fd.io. Previous CSIT releases are also linked from there. The current CSIT report can be found [here](https://csit.fd.io/cdocs/release_notes/current/)!

--- a/content/news/press/vpp2402.md
+++ b/content/news/press/vpp2402.md
@@ -1,0 +1,10 @@
++++
+title = "VPP 24.02 Release on 28th of February 2024"
+author = "lfnetworking"
+link = "https://s3-docs.fd.io/vpp/24.02/aboutvpp/releasenotes/v24.02.html#features"
+linkText = "Read More About VPP 24.02 Release"
+
+date = "2024-02-28"
++++
+
+**VPP 24.02 Release on 28th of February 2024"** -- The VPP 24.02 Release includes 21 new features such as new device driver infra, new native drivers (Amazon ENA, Marvel Octeon SOC, IAVF), add AES-CTR to native crypto plugin, upgrade DPDK plugin to use DPDK 23.11, RDMA driver to use version 49.0, and others. More than 262 commits were merged since the previous release, including 123 fixes. Complete list of features and bug fixes can be found in the Release notes [here](https://s3-docs.fd.io/vpp/23.10/aboutvpp/releasenotes/v23.10.html)!


### PR DESCRIPTION
Add VPP 24.02 Release announcement, CSIT 24.02 Report announcement and Calico-vpp 3.27.0 announcement to FD.io/site news.