### PR TITLE
Add GoVPP Community Meeting redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -8,3 +8,4 @@
 /docs/vpp/v2110/*      https://s3-docs.fd.io/vpp/21.10/:splat            302
 /docs/vpp/v2106/*      https://s3-docs.fd.io/vpp/21.06.0/:splat          302
 /docs/hicn/latest/*    https://hicn.readthedocs.io/:splat                302
+/govpp-meeting         https://github.com/FDio/govpp/discussions/46      302


### PR DESCRIPTION
This pull request includes a small addition to the `public/_redirects` file. The change adds a new redirect for the `govpp-meeting` URL.

* [`public/_redirects`](diffhunk://#diff-dac9f513e988b7d56b732b2ba6e52ab6c92706035815bdb05da0fb66d1697b4aR11): Added a new redirect for `govpp-meeting` to point to the relevant GitHub discussion.