### PR TITLE
version, news: VPP/CSIT Release 26.06

### DIFF
--- a/content/news/press/csit2606.md
+++ b/content/news/press/csit2606.md
@@ -1,0 +1,11 @@
++++
+title = "CSIT 26.06 Report on 8th of July 2026"
+author = "CSIT Community"
+link = "https://csit.fd.io/cdocs/release_notes/current/"
+linkText = "Read More About CSIT 26.06 Report"
+
+date = "2026-07-08"
++++
+
+**CSIT 26.06 Report on 8th of July 2026** -- The CSIT report information can be found in csit.fd.io. Previous CSIT
+releases are also linked from there. The current CSIT report can be found [here](https://csit.fd.io/cdocs/release_notes/current/)!

--- a/content/news/press/vpp2606.md
+++ b/content/news/press/vpp2606.md
@@ -1,0 +1,16 @@
++++
+title = "VPP 26.06 Release on 24th of June 2026"
+author = "VPP Community"
+link = "https://s3-docs.fd.io/vpp/26.06/aboutvpp/releasenotes/v26.06.html#features"
+linkText = "Read More About VPP 26.06 Release"
+
+date = "2026-06-24"
++++
+
+**VPP 26.06 Release on 24th of June 2026** -- The VPP 26.06 Release includes 28
+new features such as the Marvell scalable mGig NIC driver, CNAT SNAT/DNAT policy
+support, HTTP/3 CONNECT and UDP proxying, IKEv2 cryptographic enhancements, the
+Trace Path plugin, IPv6 Duplicate Address Detection, and others. More than 632 commits
+were merged since the previous release, including 265 fixes. Complete list of
+features and bug fixes can be found in the Release Notes
+[here](https://s3-docs.fd.io/vpp/26.06/aboutvpp/releasenotes/v26.06.html)!

--- a/public/_redirects
+++ b/public/_redirects
@@ -2,7 +2,7 @@
 # options available here :
 # https://docs.netlify.com/routing/redirects/redirect-options/
 /docs/tsc/FD.IO-Technical-Community-Document-12-12-2017.pdf /getinvolved/tscdocs/ 302
-/docs/vpp/master/*     https://s3-docs.fd.io/vpp/26.06/:splat            302
+/docs/vpp/master/*     https://s3-docs.fd.io/vpp/26.10/:splat            302
 /docs/vpp/v2206/*      https://s3-docs.fd.io/vpp/22.06/:splat            302
 /docs/vpp/v2202/*      https://s3-docs.fd.io/vpp/22.02/:splat            302
 /docs/vpp/v2110/*      https://s3-docs.fd.io/vpp/21.10/:splat            302

--- a/static/vpp_versions.json
+++ b/static/vpp_versions.json
@@ -1,6 +1,10 @@
 [
 	{
-		"name": "master (26.06-rc)",
+		"name": "master (26.10-rc)",
+		"link": "https://s3-docs.fd.io/vpp/26.10/"
+	},
+	{
+		"name": "26.06",
 		"link": "https://s3-docs.fd.io/vpp/26.06/"
 	},
 	{


### PR DESCRIPTION
- Update VPP version for Release 26.06
- Add News articles for VPP/CSIT Release 26.06